### PR TITLE
Use stable instead of alpha version

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -29,14 +29,14 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
 
   - run:
-      name: gcloud alpha auth configure-docker
+      name: gcloud auth configure-docker
       command: |
         # Set sudo to work whether logged in as root user or non-root user
         if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
         # configure Docker to use gcloud as a credential helper
         mkdir -p /home/circleci/.docker
-        $SUDO gcloud alpha auth configure-docker --quiet --project $<<parameters.google-project-id>>
+        $SUDO gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
 
         # if applicable, provide circleci user access to the docker config file
         if [[ -d /home/circleci/.docker ]]; then


### PR DESCRIPTION
Fixes #13.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
This orb still use alpha version of gcloud command `auth configure-docker` #13. Even though there is stable version, and the documentation also use stable version https://cloud.google.com/container-registry/docs/pushing-and-pulling.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Just remove `alpha` keyword from command.