### PR TITLE
remove dependency on circleci user

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -35,13 +35,13 @@ steps:
         if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
         # configure Docker to use gcloud as a credential helper
-        mkdir -p /home/circleci/.docker
+        mkdir -p "$HOME/.docker"
         gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
 
-        # if applicable, provide circleci user access to the docker config file
-        if [[ -d /home/circleci/.docker ]]; then
-          $SUDO chown circleci:circleci /home/circleci/.docker -R
+        # if applicable, provide user access to the docker config file
+        if [[ -d "$HOME/.docker" ]]; then
+          $SUDO chown "$USER:$USER" "$HOME/.docker" -R
         fi
-        if [[ -d /home/circleci/.config ]]; then
-          $SUDO chown circleci:circleci /home/circleci/.config -R
+        if [[ -d "$HOME/.config" ]]; then
+          $SUDO chown "$USER:$USER" "$HOME/.config" -R
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/gcp-gcr-orb/issues/4

orb doesn't work with images that don't have a `circleci` user (i.e., any non-`circleci/` images)

### Description

use `$USER` & `$HOME` to be more image-agnostic
