### PR TITLE
Improve gcr-auth by removing unnecessary commands

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -29,19 +29,6 @@ steps:
       gcloud-service-key: <<parameters.gcloud-service-key>>
 
   - run:
-      name: gcloud auth configure-docker
+      name: Register gcloud as a Docker credential helper
       command: |
-        # Set sudo to work whether logged in as root user or non-root user
-        if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
-
-        # configure Docker to use gcloud as a credential helper
-        mkdir -p "$HOME/.docker"
         gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
-
-        # if applicable, provide user access to the docker config file
-        if [[ -d "$HOME/.docker" ]]; then
-          $SUDO chown "$USER:$USER" "$HOME/.docker" -R
-        fi
-        if [[ -d "$HOME/.config" ]]; then
-          $SUDO chown "$USER:$USER" "$HOME/.config" -R
-        fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
after issue #19  is fixed (9de3d28), I think there are some commands that are no longer needed, so it can be simplified with just one command line.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
When running `gcr-auth` we don't use sudo anymore, so the commands before and after are no longer needed. Also when running the gcr-auth folder `$HOME/.docker` will be automatically created.