### PR TITLE
added a tag command and job

### DIFF
--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -1,0 +1,32 @@
+description: Push a container image to the GCR registry
+
+parameters:
+  registry-url:
+    description: 'The GCR registry URL from ['''', us, eu, asia].gcr.io'
+    type: string
+    default: gcr.io
+
+  google-project-id:
+    description: The Google project ID to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_PROJECT_ID
+
+  image: 
+    description: A docker image name
+    type: string
+
+  source-tag:
+    description: An existing docker image tag
+    type: string
+
+  target-tag:
+    description: A new docker image tag
+    type: string
+
+steps:
+  - run:
+      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.source-tag>>
+      command: |
+        IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>
+        gcloud container images add-tag --quiet "${IMAGE_ROOT}:<<parameters.source-tag>>" "${IMAGE_ROOT}:<<parameters.target-tag>>"
+        

--- a/src/examples/tag-existing-image.yml
+++ b/src/examples/tag-existing-image.yml
@@ -1,0 +1,18 @@
+description: >
+  Log into Google Cloud Plaform, then tag an existing image with "latest"
+
+usage:
+  version: 2.1
+
+  orbs:
+    gcp-gcr: circleci/gcp-gcr@x.y.z
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        - gcp-gcr/add-image-tag:
+            context: myContext # your context containing gcloud login variables
+            registry-url: us.gcr.io # gcr.io, eu.gcr.io, asia.gcr.io
+            image: my-image # your image name
+            source-tag: mytag1 # an existing tag
+            target-tag: mytag2 # the new tag you want to add

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -1,0 +1,51 @@
+description: >
+  Install GCP CLI, if needed, and configure. Adds a tag to an existing image.
+
+executor: default
+
+parameters:
+  gcloud-service-key:
+    description: The gcloud service key
+    type: env_var_name
+    default: GCLOUD_SERVICE_KEY
+
+  google-project-id:
+    description: The Google project ID to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_PROJECT_ID
+
+  google-compute-zone:
+    description: The Google compute zone to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_ZONE
+
+  registry-url:
+    description: The GCR registry URL from ['', us, eu, asia].gcr.io
+    type: string
+    default: gcr.io
+
+  image:
+    description: A name for your docker image
+    type: string
+
+  source-tag:
+    description: An existing docker image tag
+    type: string
+
+  target-tag:
+    description: A new docker image tag
+    type: string
+
+steps:
+
+  - gcr-auth:
+      google-project-id: <<parameters.google-project-id>>
+      google-compute-zone: <<parameters.google-compute-zone>>
+      gcloud-service-key: <<parameters.gcloud-service-key>>
+
+  - tag-image:
+      registry-url: <<parameters.registry-url>>
+      google-project-id: <<parameters.google-project-id>>
+      image: <<parameters.image>>
+      source-tag: << parameters.source-tag >>
+      target-tag: << parametrs.target-tag >>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary => not necessary, I believe

### Motivation, issues

Adding a tag to an existing docker image is quite a common task in a CI process (promote a version, have sha1 + `dev`, have the git tag reflected in the docker image name...)

Also a potential fix for #8.

### Description

- add `tag-image` command, that uses `gcloud containers image add-tag` to add a tag to an existing image.
- add `add-image-tag` job, that installs & configure `gcloud`, and tags the image
- add an example of `add-image-tag`
