### PR TITLE
Add tag job command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ integration-master_filters: &integration-master_filters
 prod-deploy_requires: &prod-deploy_requires
   [
     build-and-push-image-master,
-    build-push-defaults-master
+    build-push-defaults-master,
     tag-image-master
   ]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ prod-deploy_requires: &prod-deploy_requires
   [
     build-and-push-image-master,
     build-push-defaults-master
+    tag-image-master
   ]
 
 workflows:
@@ -99,6 +100,15 @@ workflows:
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
           filters: *integration-dev_filters
 
+      - gcp-gcr/add-image-tag:
+          name: tag-image-dev
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          target-tag: testing-dev
+          filters: *integration-dev_filters
+
       # test orb jobs with default values only
       - gcp-gcr/build-and-push-image:
           name: build-push-defaults-dev
@@ -121,6 +131,15 @@ workflows:
           registry-url: us.gcr.io
           image: sample-image
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
+          filters: *integration-master_filters
+
+      - gcp-gcr/add-image-tag:
+          name: tag-image-master
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          target-tag: testing-master
           filters: *integration-master_filters
 
       # test orb jobs with default values only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,24 +62,19 @@ workflows:
       - orb-tools/lint
 
       - orb-tools/pack:
-          requires:
-            - orb-tools/lint
+          requires: {orb-tools/lint}
 
       - orb-tools/publish-dev:
           orb-name: circleci/gcp-gcr
           context: orb-publishing
-          requires:
-            - orb-tools/pack
+          requires: [orb-tools/pack]
 
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           context: orb-publishing
           ssh-fingerprints: be:d5:b0:4f:41:21:6a:0b:77:19:c4:35:22:a5:1b:11
-          requires:
-            - orb-tools/publish-dev
-          filters:
-            branches:
-              ignore: master
+          requires: [orb-tools/publish-dev]
+          filters: {branches: {ignore: master}}
 
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-master
@@ -87,11 +82,8 @@ workflows:
           cleanup-tags: true
           ssh-fingerprints: be:d5:b0:4f:41:21:6a:0b:77:19:c4:35:22:a5:1b:11
           tag: master
-          requires:
-            - orb-tools/publish-dev
-          filters:
-            branches:
-              only: master
+          requires: [orb-tools/publish-dev]
+          filters: {branches: {only: master}}
 
   integration_test-prod_deploy:
     jobs:
@@ -169,10 +161,8 @@ workflows:
           orb-name: circleci/gcp-gcr
           requires: *prod-deploy_requires
           filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-patch.*/
+            branches: {ignore: /.*/}
+            tags: {only: /master-patch.*/}
 
       - orb-tools/dev-promote-prod:
           name: dev-promote-minor
@@ -181,10 +171,8 @@ workflows:
           release: minor
           requires: *prod-deploy_requires
           filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
+            branches: {ignore: /.*/}
+            tags: {only: /master-minor.*/}
 
       - orb-tools/dev-promote-prod:
           name: dev-promote-major
@@ -193,7 +181,5 @@ workflows:
           release: major
           requires: *prod-deploy_requires
           filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/
+            branches: {ignore: /.*/}
+            tags: {only: /master-major.*/}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
           context: orb-publishing
           registry-url: us.gcr.io
           image: sample-image
+          source-tag: "$(cat TAG)"
           target-tag: testing-master
           filters: *integration-master_filters
           requires: [build-and-push-image-master]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,21 +100,20 @@ workflows:
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
           filters: *integration-dev_filters
 
-      - gcp-gcr/add-image-tag:
-          name: tag-image-dev
-          context: orb-publishing
-          registry-url: us.gcr.io
-          image: sample-image
-          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
-          target-tag: testing-dev
-          filters: *integration-dev_filters
-
       # test orb jobs with default values only
       - gcp-gcr/build-and-push-image:
           name: build-push-defaults-dev
           requires:
             - test-orb-commands-dev
           image: sample-image
+          filters: *integration-dev_filters
+
+      - gcp-gcr/add-image-tag:
+          name: tag-image-dev
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          target-tag: testing-dev
           filters: *integration-dev_filters
 
       # triggered by master branch commits
@@ -133,21 +132,20 @@ workflows:
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
           filters: *integration-master_filters
 
-      - gcp-gcr/add-image-tag:
-          name: tag-image-master
-          context: orb-publishing
-          registry-url: us.gcr.io
-          image: sample-image
-          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
-          target-tag: testing-master
-          filters: *integration-master_filters
-
       # test orb jobs with default values only
       - gcp-gcr/build-and-push-image:
           name: build-push-defaults-master
           requires:
             - test-orb-commands-master
           image: sample-image
+          filters: *integration-master_filters
+
+      - gcp-gcr/add-image-tag:
+          name: tag-image-master
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          target-tag: testing-master
           filters: *integration-master_filters
 
       # patch, minor, or major publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,17 @@ integration-master_filters: &integration-master_filters
   tags:
     only: /master-.*/
 
+push-job-post-steps: &push-job-post-steps
+  [
+    run: "echo \"${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM\" > TAG",
+    persist_to_workspace: {root: ., paths: [TAG]}
+  ]
+
+tag-job-pre-steps: &tag-job-pre-steps
+  [
+    attach_workspace: {at: .}
+  ]
+
 prod-deploy_requires: &prod-deploy_requires
   [
     build-and-push-image-master,
@@ -93,19 +104,29 @@ workflows:
       # test orb jobs
       - gcp-gcr/build-and-push-image:
           name: build-and-push-image-dev
-          requires:
-            - test-orb-commands-dev
           registry-url: us.gcr.io
           image: sample-image
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
+          requires: [test-orb-commands-dev]
           filters: *integration-dev_filters
+          post-steps: *push-job-post-steps
+
+      - gcp-gcr/add-image-tag:
+          name: tag-image-dev
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          source-tag: "$(cat TAG)"
+          target-tag: testing-dev
+          requires: [build-and-push-image-dev]
+          filters: *integration-dev_filters
+          pre-steps: *tag-job-pre-steps
 
       # test orb jobs with default values only
       - gcp-gcr/build-and-push-image:
           name: build-push-defaults-dev
-          requires:
-            - test-orb-commands-dev
           image: sample-image
+          requires: [test-orb-commands-dev]
           filters: *integration-dev_filters
 
       - gcp-gcr/add-image-tag:
@@ -114,6 +135,7 @@ workflows:
           registry-url: us.gcr.io
           image: sample-image
           target-tag: testing-dev
+          requires: [build-push-defaults-dev]
           filters: *integration-dev_filters
 
       # triggered by master branch commits
@@ -125,20 +147,12 @@ workflows:
       # test orb jobs
       - gcp-gcr/build-and-push-image:
           name: build-and-push-image-master
-          requires:
-            - test-orb-commands-master
           registry-url: us.gcr.io
           image: sample-image
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUM
+          requires: [test-orb-commands-master]
           filters: *integration-master_filters
-
-      # test orb jobs with default values only
-      - gcp-gcr/build-and-push-image:
-          name: build-push-defaults-master
-          requires:
-            - test-orb-commands-master
-          image: sample-image
-          filters: *integration-master_filters
+          post-steps: *push-job-post-steps
 
       - gcp-gcr/add-image-tag:
           name: tag-image-master
@@ -147,6 +161,24 @@ workflows:
           image: sample-image
           target-tag: testing-master
           filters: *integration-master_filters
+          requires: [build-and-push-image-master]
+          pre-steps: *tag-job-pre-steps
+
+      # test orb jobs with default values only
+      - gcp-gcr/build-and-push-image:
+          name: build-push-defaults-master
+          image: sample-image
+          requires: [test-orb-commands-master]
+          filters: *integration-master_filters
+
+      - gcp-gcr/add-image-tag:
+          name: tag-image-defaults-master
+          context: orb-publishing
+          registry-url: us.gcr.io
+          image: sample-image
+          target-tag: testing-defaults-master
+          filters: *integration-master_filters
+          requires: [build-push-defaults-master]
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
       - orb-tools/lint
 
       - orb-tools/pack:
-          requires: {orb-tools/lint}
+          requires: [orb-tools/lint]
 
       - orb-tools/publish-dev:
           orb-name: circleci/gcp-gcr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,15 +129,6 @@ workflows:
           requires: [test-orb-commands-dev]
           filters: *integration-dev_filters
 
-      - gcp-gcr/add-image-tag:
-          name: tag-image-dev
-          context: orb-publishing
-          registry-url: us.gcr.io
-          image: sample-image
-          target-tag: testing-dev
-          requires: [build-push-defaults-dev]
-          filters: *integration-dev_filters
-
       # triggered by master branch commits
       # test orb commands
       - test-orb-commands:
@@ -170,15 +161,6 @@ workflows:
           image: sample-image
           requires: [test-orb-commands-master]
           filters: *integration-master_filters
-
-      - gcp-gcr/add-image-tag:
-          name: tag-image-defaults-master
-          context: orb-publishing
-          registry-url: us.gcr.io
-          image: sample-image
-          target-tag: testing-defaults-master
-          filters: *integration-master_filters
-          requires: [build-push-defaults-master]
 
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 orbs:
   gcp-gcr: circleci/gcp-gcr@dev:alpha
-  orb-tools: circleci/orb-tools@8.9.2
+  orb-tools: circleci/orb-tools@8.14.0
 
 jobs:
   test-orb-commands:

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+circleci config pack src > orb.yml
+circleci orb publish orb.yml circleci/gcp-gcr@dev:alpha
+rm -rf orb.yml

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -11,17 +11,17 @@ parameters:
     type: env_var_name
     default: GOOGLE_PROJECT_ID
 
-  image: 
-    description: A docker image name
+  image:
     type: string
+    description: A Docker image name
 
   source-tag:
-    description: An existing docker image tag
     type: string
+    description: An existing Docker image tag
 
   target-tag:
-    description: A new docker image tag
     type: string
+    description: A new Docker image tag
 
 steps:
   - run:
@@ -29,4 +29,3 @@ steps:
       command: |
         IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>
         gcloud container images add-tag --quiet "${IMAGE_ROOT}:<<parameters.source-tag>>" "${IMAGE_ROOT}:<<parameters.target-tag>>"
-        

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -15,7 +15,7 @@ parameters:
     type: string
     description: A Docker image name
 
-source-tag:
+  source-tag:
     type: string
     default: ""
     description: >

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -15,10 +15,12 @@ parameters:
     type: string
     description: A Docker image name
 
-  source-tag:
+source-tag:
     type: string
-    description: An existing Docker image tag
-    default: latest
+    default: ""
+    description: >
+      An existing Docker image tag. If left blank, the most recently
+      pushed image will be tagged with the value of `target-tag`.
 
   target-tag:
     type: string
@@ -26,7 +28,9 @@ parameters:
 
 steps:
   - run:
-      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.source-tag>>
+      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>><<#parameters.source-tag>>:<<parameters.source-tag>><</parameters.source-tag>>
       command: |
         IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>
-        gcloud container images add-tag --quiet "${IMAGE_ROOT}:<<parameters.source-tag>>" "${IMAGE_ROOT}:<<parameters.target-tag>>"
+        gcloud container images add-tag --quiet \
+          "${IMAGE_ROOT}<<#parameters.source-tag>>:<<parameters.source-tag>><</parameters.source-tag>>" \
+          "${IMAGE_ROOT}:<<parameters.target-tag>>"

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -1,0 +1,32 @@
+description: Push a container image to the GCR registry
+
+parameters:
+  registry-url:
+    description: 'The GCR registry URL from ['''', us, eu, asia].gcr.io'
+    type: string
+    default: gcr.io
+
+  google-project-id:
+    description: The Google project ID to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_PROJECT_ID
+
+  image: 
+    description: A docker image name
+    type: string
+
+  source-tag:
+    description: An existing docker image tag
+    type: string
+
+  target-tag:
+    description: A new docker image tag
+    type: string
+
+steps:
+  - run:
+      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.source-tag>>
+      command: |
+        IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>
+        gcloud container images add-tag --quiet "${IMAGE_ROOT}:<<parameters.source-tag>>" "${IMAGE_ROOT}:<<parameters.target-tag>>"
+        

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -18,6 +18,7 @@ parameters:
   source-tag:
     type: string
     description: An existing Docker image tag
+    default: latest
 
   target-tag:
     type: string

--- a/src/commands/tag-image.yml
+++ b/src/commands/tag-image.yml
@@ -17,10 +17,7 @@ parameters:
 
   source-tag:
     type: string
-    default: ""
-    description: >
-      An existing Docker image tag. If left blank, the most recently
-      pushed image will be tagged with the value of `target-tag`.
+    description: An existing Docker image tag
 
   target-tag:
     type: string
@@ -28,9 +25,9 @@ parameters:
 
 steps:
   - run:
-      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>><<#parameters.source-tag>>:<<parameters.source-tag>><</parameters.source-tag>>
+      name: Add <<parameters.target-tag>> tag to <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.source-tag>>
       command: |
         IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>
         gcloud container images add-tag --quiet \
-          "${IMAGE_ROOT}<<#parameters.source-tag>>:<<parameters.source-tag>><</parameters.source-tag>>" \
+          "${IMAGE_ROOT}:<<parameters.source-tag>>" \
           "${IMAGE_ROOT}:<<parameters.target-tag>>"

--- a/src/examples/tag-existing-image.yml
+++ b/src/examples/tag-existing-image.yml
@@ -1,0 +1,18 @@
+description: >
+  Log into Google Cloud Plaform, then tag an existing image with "latest"
+
+usage:
+  version: 2.1
+
+  orbs:
+    gcp-gcr: circleci/gcp-gcr@x.y.z
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        - gcp-gcr/add-image-tag:
+            context: myContext # your context containing gcloud login variables
+            registry-url: us.gcr.io # gcr.io, eu.gcr.io, asia.gcr.io
+            image: my-image # your image name
+            source-tag: mytag1 # an existing tag
+            target-tag: mytag2 # the new tag you want to add

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -1,0 +1,51 @@
+description: >
+  Install GCP CLI, if needed, and configure. Adds a tag to an existing image.
+
+executor: default
+
+parameters:
+  gcloud-service-key:
+    description: The gcloud service key
+    type: env_var_name
+    default: GCLOUD_SERVICE_KEY
+
+  google-project-id:
+    description: The Google project ID to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_PROJECT_ID
+
+  google-compute-zone:
+    description: The Google compute zone to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_ZONE
+
+  registry-url:
+    description: The GCR registry URL from ['', us, eu, asia].gcr.io
+    type: string
+    default: gcr.io
+
+  image:
+    description: A name for your docker image
+    type: string
+
+  source-tag:
+    description: An existing docker image tag
+    type: string
+
+  target-tag:
+    description: A new docker image tag
+    type: string
+
+steps:
+
+  - gcr-auth:
+      google-project-id: <<parameters.google-project-id>>
+      google-compute-zone: <<parameters.google-compute-zone>>
+      gcloud-service-key: <<parameters.gcloud-service-key>>
+
+  - tag-image:
+      registry-url: <<parameters.registry-url>>
+      google-project-id: <<parameters.google-project-id>>
+      image: <<parameters.image>>
+      source-tag: << parameters.source-tag >>
+      target-tag: << parametrs.target-tag >>

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -30,10 +30,7 @@ parameters:
 
   source-tag:
     type: string
-    default: ""
-    description: >
-      An existing Docker image tag. If left blank, the most recently
-      pushed image will be tagged with the value of `target-tag`.
+    description: An existing Docker image tag
 
   target-tag:
     type: string

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -29,13 +29,15 @@ parameters:
     type: string
 
   source-tag:
-    description: An existing Docker image tag
     type: string
-    default: latest
+    default: ""
+    description: >
+      An existing Docker image tag. If left blank, the most recently
+      pushed image will be tagged with the value of `target-tag`.
 
   target-tag:
-    description: A new Docker image tag
     type: string
+    description: A new Docker image tag
 
 steps:
 

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -47,5 +47,5 @@ steps:
       registry-url: <<parameters.registry-url>>
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
-      source-tag: << parameters.source-tag >>
-      target-tag: << parametrs.target-tag >>
+      source-tag: <<parameters.source-tag>>
+      target-tag: <<parametrs.target-tag>>

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -25,15 +25,16 @@ parameters:
     default: gcr.io
 
   image:
-    description: A name for your docker image
+    description: A name for your Docker image
     type: string
 
   source-tag:
-    description: An existing docker image tag
+    description: An existing Docker image tag
     type: string
+    default: latest
 
   target-tag:
-    description: A new docker image tag
+    description: A new Docker image tag
     type: string
 
 steps:
@@ -48,4 +49,4 @@ steps:
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
       source-tag: <<parameters.source-tag>>
-      target-tag: <<parametrs.target-tag>>
+      target-tag: <<parameters.target-tag>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -31,7 +31,7 @@ parameters:
   tag:
     description: A docker image tag
     type: string
-    default: "latest"
+    default: latest
 
   path-to-dockerfile:
     description: The relative path to the Dockerfile to use when building image


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary 

### Motivation, issues

https://github.com/CircleCI-Public/gcp-gcr-orb/issues/8

### Description

from @benjlevesque (see https://github.com/CircleCI-Public/gcp-gcr-orb/pull/23): 

> Adding a tag to an existing docker image is quite a common task in a CI process (promote a version, have sha1 + `dev`, have the git tag reflected in the docker image name...)
> 
> - add `tag-image` command, that uses `gcloud containers image add-tag` to add a tag to an existing image.
> - add `add-image-tag` job, that installs & configure `gcloud`, and tags the image
> - add an example of `add-image-tag`