### PR TITLE
use docker orb, add extra build args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 orbs:
   gcp-gcr: circleci/gcp-gcr@dev:alpha
-  orb-tools: circleci/orb-tools@8.14.0
+  orb-tools: circleci/orb-tools@8.27.1
 
 jobs:
   test-orb-commands:
@@ -160,6 +160,7 @@ workflows:
           name: dev-promote-patch
           context: orb-publishing
           orb-name: circleci/gcp-gcr
+          ssh-fingerprints: be:d5:b0:4f:41:21:6a:0b:77:19:c4:35:22:a5:1b:11
           requires: *prod-deploy_requires
           filters:
             branches: {ignore: /.*/}
@@ -170,6 +171,7 @@ workflows:
           context: orb-publishing
           orb-name: circleci/gcp-gcr
           release: minor
+          ssh-fingerprints: be:d5:b0:4f:41:21:6a:0b:77:19:c4:35:22:a5:1b:11
           requires: *prod-deploy_requires
           filters:
             branches: {ignore: /.*/}
@@ -180,6 +182,7 @@ workflows:
           context: orb-publishing
           orb-name: circleci/gcp-gcr
           release: major
+          ssh-fingerprints: be:d5:b0:4f:41:21:6a:0b:77:19:c4:35:22:a5:1b:11
           requires: *prod-deploy_requires
           filters:
             branches: {ignore: /.*/}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
           registry-url: us.gcr.io
           image: sample-image
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
-          path-to-dockerfile: .
 
       - gcp-gcr/push-image:
           registry-url: us.gcr.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       # test orb commands
       - checkout
-
       - gcp-gcr/gcr-auth
 
       - gcp-gcr/build-image:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,4 +5,5 @@ description: >
   orb's source: https://github.com/CircleCI-Public/gcp-gcr-orb
 
 orbs:
+  docker: circleci/docker@0.5.1
   gcp-cli: circleci/gcp-cli@1.3.0

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -44,7 +44,7 @@ steps:
       step-name: Build Docker image for GCR
       dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
-      registry: <<parameters.registry-url>>/<<parameters.google-project-id>>
+      registry: "<<parameters.registry-url>>/$<<parameters.google-project-id>>"
       image: <<parameters.image>>
       tag: <<parameters.tag>>
       extra_build_args: <<parameters.extra_build_args>>

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -20,15 +20,31 @@ parameters:
     default: latest
     description: A Docker image tag
 
-  path-to-dockerfile:
+  dockerfile:
     type: string
-    default: "."
-    description: The relative path to the Dockerfile to use when building image
+    default: Dockerfile
+    description: Name of dockerfile to use, defaults to Dockerfile
+
+  path:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your Dockerfile and build context,
+      defaults to . (working directory)
+
+  extra_build_args:
+    type: string
+    default: ""
+    description: >
+      Extra flags to pass to docker build. For examples, see
+      https://docs.docker.com/engine/reference/commandline/build
 
 steps:
-  - run:
-      name: Build docker image
-      command: |
-        docker build -t \
-          <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>> \
-          <<parameters.path-to-dockerfile>>
+  - docker/build:
+      step-name: Build Docker image for GCR
+      dockerfile: <<parameters.dockerfile>>
+      path: <<parameters.path>>
+      registry: <<parameters.registry-url>>/<<parameters.google-project-id>>
+      image: <<parameters.image>>
+      tag: <<parameters.tag>>
+      extra_build_args: <<parameters.extra_build_args>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -25,18 +25,32 @@ parameters:
     default: gcr.io
 
   image:
-    description: A name for your docker image
     type: string
+    description: A name for your Docker image
 
   tag:
-    description: A docker image tag
     type: string
     default: latest
+    description: A Docker image tag
 
-  path-to-dockerfile:
-    description: The relative path to the Dockerfile to use when building image
+  dockerfile:
     type: string
-    default: "."
+    default: Dockerfile
+    description: Name of dockerfile to use, defaults to Dockerfile
+
+  path:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your Dockerfile and build context,
+      defaults to . (working directory)
+
+  extra_build_args:
+    type: string
+    default: ""
+    description: >
+      Extra flags to pass to docker build. For examples, see
+      https://docs.docker.com/engine/reference/commandline/build
 
 steps:
   - checkout
@@ -50,8 +64,10 @@ steps:
       registry-url: <<parameters.registry-url>>
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
-      tag: << parameters.tag >>
-      path-to-dockerfile: <<parameters.path-to-dockerfile>>
+      tag: <<parameters.tag>>
+      dockerfile: <<parameters.dockerfile>>
+      path: <<parameters.path>>
+      extra_build_args: <<parameters.extra_build_args>>
 
   - push-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/gcp-gcr-orb/issues/25#issuecomment-507591666

### Description

- import `build` command from `circleci/docker` orb
- add `build` command's `extra_build_args` param to this orb
