### PR TITLE
[semver:minor] Enable custom executor and DLC

### DIFF
--- a/src/examples/optimized-build-and-push.yml
+++ b/src/examples/optimized-build-and-push.yml
@@ -23,4 +23,4 @@ usage:
             image: my-image # your image name
             executor: my-executor # choose an image with gcloud already installed
             setup-remote-docker: true # mandatory for custom docker executor
-            use-docker-layer-caching: true # optional, improved performance. 
+            use-docker-layer-caching: true # optional, improved performance.

--- a/src/examples/optimized-build-and-push.yml
+++ b/src/examples/optimized-build-and-push.yml
@@ -1,0 +1,27 @@
+description: >
+  Log into Google Cloud Plaform, then build and push image to GCR. Uses a custom executor to reduce the setup time.
+
+usage:
+  version: 2.1
+
+  orbs:
+    gcp-gcr: circleci/gcp-gcr@x.y.z
+
+  executors:
+    my-executor:
+      docker:
+        # choose an image that contains the gcloud CLI to avoid installation during CI
+        # you can extend CircleCI base images https://circleci.com/docs/2.0/circleci-images/#circleci-base-image
+        # example: https://github.com/RequestNetwork/circleci/blob/master/python/3.7/Dockerfile
+        - image: requestnetwork/circleci-python:3.7
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        - gcp-gcr/build-and-push-image:
+            context: myContext # your context containing gcloud login variables
+            registry-url: us.gcr.io # gcr.io, eu.gcr.io, asia.gcr.io
+            image: my-image # your image name
+            executor: my-executor # choose an image with gcloud already installed
+            setup-remote-docker: true # mandatory for custom docker executor
+            use-docker-layer-caching: true # optional, improved performance. 

--- a/src/examples/optimized-build-and-push.yml
+++ b/src/examples/optimized-build-and-push.yml
@@ -12,8 +12,7 @@ usage:
       docker:
         # choose an image that contains the gcloud CLI to avoid installation during CI
         # you can extend CircleCI base images https://circleci.com/docs/2.0/circleci-images/#circleci-base-image
-        # example: https://github.com/RequestNetwork/circleci/blob/master/python/3.7/Dockerfile
-        - image: requestnetwork/circleci-python:3.7
+        - image: my-org/circleci-python:3.7
 
   workflows:
     build_and_push_image:

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -1,9 +1,14 @@
 description: >
   Install GCP CLI, if needed, and configure. Adds a tag to an existing image.
 
-executor: default
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    default: default
+    description: executor to use for this job
+    type: executor
+
   gcloud-service-key:
     description: The gcloud service key
     type: env_var_name

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -75,7 +75,7 @@ parameters:
     type: boolean
   use-docker-layer-caching:
     default: false
-    description: | 
+    description: |
       Setup docker layer caching for optimized build. Not available if using the default executor.
     type: boolean
 
@@ -85,8 +85,8 @@ steps:
   - when:
       condition: <<parameters.setup-remote-docker>>
       steps:
-      - setup_remote_docker:
-          docker_layer_caching: <<parameters.use-docker-layer-caching>>
+        - setup_remote_docker:
+            docker_layer_caching: <<parameters.use-docker-layer-caching>>
 
   - gcr-auth:
       google-project-id: <<parameters.google-project-id>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -1,9 +1,14 @@
 description: >
   Install GCP CLI, if needed, and configure. Build and push image to repository.
 
-executor: default
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    default: default
+    description: executor to use for this job
+    type: executor
+
   gcloud-service-key:
     description: The gcloud service key
     type: env_var_name
@@ -63,9 +68,25 @@ parameters:
     description: >
       Path to the directory containing your build context, defaults to .
       (working directory)
+  setup-remote-docker:
+    default: false
+    description: |
+      Setup and use CircleCI's remote Docker environment for Docker and docker-compose commands? Not required if using the default executor
+    type: boolean
+  use-docker-layer-caching:
+    default: false
+    description: | 
+      Setup docker layer caching for optimized build. Not available if using the default executor.
+    type: boolean
 
 steps:
   - checkout
+
+  - when:
+      condition: <<parameters.setup-remote-docker>>
+      steps:
+      - setup_remote_docker:
+          docker_layer_caching: <<parameters.use-docker-layer-caching>>
 
   - gcr-auth:
       google-project-id: <<parameters.google-project-id>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

GCloud CLI installation can take up to 2 minues for each build. 

With a custom docker image that already has gcloud installed, the build time is significantly reduced. 

Related issue: https://github.com/CircleCI-Public/gcp-gcr-orb/issues/30

### Description

Adds optional parameters to `build-and-push-image` job for executor, docker-remote-setup and docker-layer-cache.

Adds optional parameter to `add-image-tag` job for executor.

This was inspired from https://github.com/CircleCI-Public/aws-ecr-orb
