### PR TITLE
pass docker-context through to docker/build command

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -39,10 +39,18 @@ parameters:
       Extra flags to pass to docker build. For examples, see
       https://docs.docker.com/engine/reference/commandline/build
 
+  docker-context:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your build context, defaults to .
+      (working directory)
+
 steps:
   - docker/build:
       step-name: Build Docker image for GCR
       dockerfile: <<parameters.dockerfile>>
+      docker-context: <<parameters.docker-context>>
       path: <<parameters.path>>
       registry: "<<parameters.registry-url>>/$<<parameters.google-project-id>>"
       image: <<parameters.image>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -57,6 +57,13 @@ parameters:
     description: (Optional) The path to save the RepoDigest of the pushed image
     default: ""
 
+  docker-context:
+    type: string
+    default: .
+    description: >
+      Path to the directory containing your build context, defaults to .
+      (working directory)
+
 steps:
   - checkout
 
@@ -73,6 +80,7 @@ steps:
       dockerfile: <<parameters.dockerfile>>
       path: <<parameters.path>>
       extra_build_args: <<parameters.extra_build_args>>
+      docker-context: <<parameters.docker-context>>
 
   - push-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This orb doesn't currently pass the docker-context through to the docker/build command which means it's getting set to the root of the path, this breaks any docker build for repos that don't keep the dockerfile at the root of the docker context (e.g any monorepo with shared code at a higher level).

### Description

Added the docker-context as a param to the build-image command and the build-and-push-image job 
