### PR TITLE
update docker-orb and support no_output_timout parameter [semver:minor]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,5 @@ display:
   source_url: "https://github.com/CircleCI-Public/gcp-gcr-orb"
 
 orbs:
-  docker: circleci/docker@dev:alpha
+  docker: circleci/docker@1.5.0
   gcp-cli: circleci/gcp-cli@1.8

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,5 @@ display:
   source_url: "https://github.com/CircleCI-Public/gcp-gcr-orb"
 
 orbs:
-  docker: circleci/docker@1.3
+  docker: circleci/docker@dev:alpha
   gcp-cli: circleci/gcp-cli@1.8

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,5 +8,5 @@ display:
   source_url: "https://github.com/CircleCI-Public/gcp-gcr-orb"
 
 orbs:
-  docker: circleci/docker@1.5.0
+  docker: circleci/docker@1.5
   gcp-cli: circleci/gcp-cli@1.8

--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -60,6 +60,13 @@ parameters:
       Path to the directory containing your build context, defaults to .
       (working directory)
 
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: >
+      Pass through a default timeout if your Docker build does not output
+      anything for more than 10 minutes.
+
 steps:
   - when:
       condition: <<parameters.attach-workspace>>
@@ -76,3 +83,4 @@ steps:
       image: <<parameters.image>>
       tag: <<parameters.tag>>
       extra_build_args: <<parameters.extra_build_args>>
+      no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/examples/build-and-push-digest.yml
+++ b/src/examples/build-and-push-digest.yml
@@ -16,6 +16,7 @@ usage:
         - gcp-gcr/build-image:
             image: orb-test
             registry-url: eu.gcr.io
+            no_output_timeout: 20m
         - gcp-gcr/push-image:
             image: orb-test
             registry-url: eu.gcr.io

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -78,6 +78,13 @@ parameters:
       Path to the directory containing your build context, defaults to .
       (working directory)
 
+  no_output_timeout:
+    type: string
+    default: "10m"
+    description: >
+      Pass through a default timeout if your Docker build does not output
+      anything for more than 10 minutes.
+
 steps:
   - checkout
 
@@ -97,6 +104,7 @@ steps:
       attach-workspace: <<parameters.attach-workspace>>
       workspace-root: <<parameters.workspace-root>>
       docker-context: <<parameters.docker-context>>
+      no_output_timeout: <<parameters.no_output_timeout>>
 
   - push-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Add no_output_timeout parameter to docker build.

## Motivation:

 Closes #41 

- [x] Waiting on https://github.com/CircleCI-Public/docker-orb/pull/76

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

Changelog...?