### PR TITLE
Support the `GOOGLE_COMPUTE_REGION` config parameter [semver:minor]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 orbs:
   docker: circleci/docker@1.5
-  gcp-cli: circleci/gcp-cli@1.8
+  gcp-cli: circleci/gcp-cli@2.1

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -20,12 +20,19 @@ parameters:
     description: >
       The Google compute zone to connect with via the gcloud CLI
 
+  google-compute-region:
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
+    description: >
+      The Google compute region to connect with via the gcloud CLI
+
 steps:
   - gcp-cli/install
 
   - gcp-cli/initialize:
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
 
   - run:

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -24,6 +24,11 @@ parameters:
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
 
+  google-compute-region:
+    description: The Google compute zone to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
+
   registry-url:
     description: The GCR registry URL from ['', us, eu, asia].gcr.io
     type: string
@@ -46,6 +51,7 @@ steps:
   - gcr-auth:
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
 
   - tag-image:

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -24,6 +24,11 @@ parameters:
     type: env_var_name
     default: GOOGLE_COMPUTE_ZONE
 
+  google-compute-region:
+    description: The Google compute zone to connect with via the gcloud CLI
+    type: env_var_name
+    default: GOOGLE_COMPUTE_REGION
+
   registry-url:
     description: The GCR registry URL from ['', us, eu, asia].gcr.io
     type: string
@@ -118,6 +123,7 @@ steps:
   - gcr-auth:
       google-project-id: <<parameters.google-project-id>>
       google-compute-zone: <<parameters.google-compute-zone>>
+      google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
 
   - build-image:


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Upgrade `gcp-cli` orb version to latest to support the `google-compute-region` parameter.

## Motivation:
GKE regional clusters require the `region` parameter rather than `zone`. This change will eventually contribute to https://github.com/CircleCI-Public/gcp-gke-orb/issues/9.
<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.