### PR TITLE
[semver:minor] Add support for pushing multiple tags at once

### DIFF
--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -16,7 +16,7 @@ parameters:
     type: string
 
   tag:
-    description: A docker image tag
+    description: Comma-separated list of docker image tags
     type: string
     default: "latest"
 
@@ -29,9 +29,12 @@ steps:
   - run:
       name: Push image to GCR
       command: |
-        docker push <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>>
+        IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.tag >>"
+        for tag in "${DOCKER_TAGS[@]}"; do
+          docker push <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:${tag}
+        done
 
         if [ -n "<<parameters.digest-path>>" ]; then
           mkdir -p "$(dirname <<parameters.digest-path>>)"
-          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:<<parameters.tag>> > "<<parameters.digest-path>>"
+          docker image inspect --format="{{index .RepoDigests 0}}" <<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.image>>:${DOCKER_TAGS[0]} > "<<parameters.digest-path>>"
         fi


### PR DESCRIPTION
The docker orb already supports creating multiple tags at one go, so if you try this today, the build will pass while the push fails. This adds the same support to push,  so one CircleCI job can build/push multiple tags.

I'd generally use this as so:

```yaml
          tag: ${CIRCLE_SHA1},latest
```

I'm opening this PR without directly related ticket as per discussion on https://github.com/CircleCI-Public/gcp-gcr-orb/issues/8#issuecomment-498375028

Based on https://github.com/CircleCI-Public/docker-orb/pull/37 with a bit of https://github.com/CircleCI-Public/docker-orb/pull/72