### PR TITLE
add support for artifact registry in registry url parameter [semver:minor]

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -31,7 +31,6 @@ parameters:
       The GCR registry URL from ['', us, eu, asia].gcr.io,
       or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pkg.dev
     type: string
-    default: gcr.io
 
 steps:
   - gcp-cli/install
@@ -51,8 +50,8 @@ steps:
         # configure Docker to use gcloud as a credential helper
         mkdir -p "$HOME/.docker"
 
-        if [[ <<parameters.registry-url>> == *docker.pkg.dev ]]; then
-          gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>> <<parameters.registry-url>>
+        if [[ -n <<parameters.registry-url>> ]]; then
+          gcloud auth configure-docker <<parameters.registry-url>> --quiet --project $<<parameters.google-project-id>>
         else
           gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
         fi

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -31,6 +31,7 @@ parameters:
       The GCR registry URL from ['', us, eu, asia].gcr.io,
       or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pkg.dev
     type: string
+    default: gcr.io
 
 steps:
   - gcp-cli/install
@@ -50,8 +51,8 @@ steps:
         # configure Docker to use gcloud as a credential helper
         mkdir -p "$HOME/.docker"
 
-        if [[ -n <<parameters.registry-url>> ]]; then
-          gcloud auth configure-docker <<parameters.registry-url>> --quiet --project $<<parameters.google-project-id>>
+        if [[ <<parameters.registry-url>> == *docker.pkg.dev ]]; then
+          gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>> <<parameters.registry-url>>
         else
           gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
         fi

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -29,7 +29,7 @@ parameters:
   registry-url:
     description: >
       The GCR registry URL from ['', us, eu, asia].gcr.io,
-      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pk.dev
+      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pkg.dev
     type: string
     default: gcr.io
 

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -26,6 +26,13 @@ parameters:
     description: >
       The Google compute region to connect with via the gcloud CLI
 
+  registry-url:
+    description: >
+      The GCR registry URL from ['', us, eu, asia].gcr.io,
+      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pk.dev
+    type: string
+    default: gcr.io
+
 steps:
   - gcp-cli/install
 
@@ -43,7 +50,12 @@ steps:
 
         # configure Docker to use gcloud as a credential helper
         mkdir -p "$HOME/.docker"
-        gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
+
+        if [[ <<parameters.registry-url>> == *docker.pkg.dev ]]; then
+          gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>> <<parameters.registry-url>>
+        else
+          gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>
+        fi
 
         # if applicable, provide user access to the docker config file
         if [[ -d "$HOME/.docker" ]]; then

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -51,7 +51,7 @@ steps:
         # configure Docker to use gcloud as a credential helper
         mkdir -p "$HOME/.docker"
 
-        if [[ <<parameters.registry-url>> == *docker.pkg.dev ]]; then
+        if [[ "<<parameters.registry-url>>" == "*docker.pkg.dev" ]]; then
           gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>> <<parameters.registry-url>>
         else
           gcloud auth configure-docker --quiet --project $<<parameters.google-project-id>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -32,7 +32,7 @@ parameters:
   registry-url:
     description: >
       The GCR registry URL from ['', us, eu, asia].gcr.io,
-      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pk.dev
+      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pkg.dev
     type: string
     default: gcr.io
 

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -30,7 +30,9 @@ parameters:
     default: GOOGLE_COMPUTE_REGION
 
   registry-url:
-    description: The GCR registry URL from ['', us, eu, asia].gcr.io
+    description: >
+      The GCR registry URL from ['', us, eu, asia].gcr.io,
+      or an artifact registry url from [GOOGLE_COMPUTE_REGION, us, eu, asia].docker.pk.dev
     type: string
     default: gcr.io
 
@@ -125,6 +127,7 @@ steps:
       google-compute-zone: <<parameters.google-compute-zone>>
       google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
+      registry-url: <<parameters.registry-url>>
 
   - build-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION
SEMVER Update type

- [ ]  Major
- [x]  Minor
- [ ]  Patch

# Description:
Allow artifact registry urls to be used as a registry url. To do this, if an artifact registry url is used as the registry url, it should be passed into the `gcloud auth configure-docker` command. Does not impact using gcr.io registry urls.

Addresses #47 

# Checklist:
- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog / Readme has been updated.