### PR TITLE
feat: update gcp-cli orbs

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 orbs:
   docker: circleci/docker@1.5
-  gcp-cli: circleci/gcp-cli@2.1
+  gcp-cli: circleci/gcp-cli@2.4.1

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -33,8 +33,15 @@ parameters:
     type: string
     default: gcr.io
 
+  gcloud-version:
+    description: >
+      The default version of gcloud to use with gcp-cli
+    type: string
+    default: "404.0.0"
+
 steps:
-  - gcp-cli/install
+  - gcp-cli/install:
+      version: <<parameters.gcloud-version>>
 
   - gcp-cli/initialize:
       google-project-id: <<parameters.google-project-id>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Updated gcp-cli to the latest version and specified the default version of gcloud that gcp-cli uses

## Motivation:
The orb can not be used because the version of python3 is high in the image maintained by circleci.

 **Closes Issues:**
-  https://github.com/CircleCI-Public/gcp-gcr-orb/issues/57
- https://github.com/CircleCI-Public/gcp-gcr-orb/issues/55

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.