### PR TITLE
[semver:patch] Update push-image to add missing ORB_VAL_IMAGE & update readme with correct hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For further questions/comments about this or other orbs, visit [CircleCI's orbs 
 
 ### How To Contribute
 
-We welcome [issues](https://github.com/CircleCI-Public/serverless-framework-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/serverless-framework-orb/pulls) against this repository!
+We welcome [issues](https://github.com/CircleCI-Public/gcp-gcr-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/gcp-gcr-orb/pulls) against this repository!
 
 To publish a new production version:
 * Create a PR to the `Alpha` branch with your changes. This will act as a "staging" branch.

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -2,6 +2,7 @@
 
 IFS="," read -ra DOCKER_TAGS <<< "$ORB_EVAL_TAG"
 PROJECT_ID="${!ORB_ENV_PROJECT_ID}"
+ORB_VAL_IMAGE=$(eval echo "$ORB_VAL_IMAGE")
 
 for tag_to_eval in "${DOCKER_TAGS[@]}"; do
     TAG=$(eval echo "$tag_to_eval")


### PR DESCRIPTION
Intent is to add ORB_VAL_IMAGE so that a pipeline value such as ${CIRCLE_PROJECT_REPONAME} can be used for `image:` in place of a hard-coded string. Also updated README.md with hyperlinks that point to gcp-gcr-orb for pull requests and issues.