### PR TITLE
feat: add oidc support for gcr-auth

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -46,18 +46,18 @@ jobs:
       - gcp-gcr/build-image:
           registry-url: us.gcr.io
           image: sample-image
-          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER.oidc
           path: ~/project/sample/
           docker-context: ~/project/sample/
       - gcp-gcr/push-image:
           registry-url: us.gcr.io
           image: sample-image
-          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER.oidc
       - gcp-gcr/tag-image:
           registry-url: us.gcr.io
           image: sample-image
-          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
-          target-tag: tagged.$CIRCLE_BUILD_NUMBER
+          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER.oidc
+          target-tag: tagged.$CIRCLE_BUILD_NUMBER.oidc
 
 workflows:
   test-deploy:
@@ -65,11 +65,8 @@ workflows:
       - integration-test-without-oidc:
           context: cpe-gcp
           filters: *filters
-      - integration-test-with-oidc:
-          context: cpe-gcp
-          filters: *filters
       - gcp-gcr/build-and-push-image:
-          name: build-and-push
+          name: build-and-push-without-oidc
           registry-url: us.gcr.io
           image: sample-image
           tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
@@ -79,7 +76,7 @@ workflows:
           context: cpe-gcp
           filters: *filters
           requires:
-            - integration-test
+            - integration-test-without-oidc
           post-steps:
             - run:
                 command: |
@@ -95,7 +92,27 @@ workflows:
           context: cpe-gcp
           filters: *filters
           requires:
-            - integration-test
+            - integration-test-without-oidc
+          post-steps:
+            - run:
+                command: |
+                  echo "Digest is: $(</tmp/digest.txt)"
+      - integration-test-with-oidc:
+          context: cpe-gcp
+          filters: *filters
+      - gcp-gcr/build-and-push-image:
+          name: build-and-push-with-oidc
+          registry-url: us.gcr.io
+          image: sample-image
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER.oidc
+          digest-path: /tmp/digest.txt
+          path: ~/project/sample/
+          docker-context: ~/project/sample/
+          use_oidc: true
+          context: cpe-gcp
+          filters: *filters
+          requires:
+            - integration-test-with-oidc
           post-steps:
             - run:
                 command: |
@@ -111,8 +128,9 @@ workflows:
           requires:
             - orb-tools/pack
             - integration-test-without-oidc
-            - integration-test-with-oidc
-            - build-and-push
+            - build-and-push-without-oidc
             - build-and-push-with-env-var
+            - integration-test-with-oidc
+            - build-and-push-with-oidc
           context: orb-publisher
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       # test orb commands
       - checkout
       - gcp-gcr/gcr-auth:
-          use-oidc: true
+          use_oidc: true
       - gcp-gcr/build-image:
           registry-url: us.gcr.io
           image: sample-image

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 jobs:
-  integration-test:
+  integration-test-without-oidc:
     executor: gcp-gcr/default
     steps:
       # test orb commands
@@ -36,10 +36,36 @@ jobs:
           image: sample-image
           source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
           target-tag: tagged.$CIRCLE_BUILD_NUMBER
+  integration-test-with-oidc:
+    executor: gcp-gcr/default
+    steps:
+      # test orb commands
+      - checkout
+      - gcp-gcr/gcr-auth:
+          use-oidc: true
+      - gcp-gcr/build-image:
+          registry-url: us.gcr.io
+          image: sample-image
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          path: ~/project/sample/
+          docker-context: ~/project/sample/
+      - gcp-gcr/push-image:
+          registry-url: us.gcr.io
+          image: sample-image
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+      - gcp-gcr/tag-image:
+          registry-url: us.gcr.io
+          image: sample-image
+          source-tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          target-tag: tagged.$CIRCLE_BUILD_NUMBER
+
 workflows:
   test-deploy:
     jobs:
-      - integration-test:
+      - integration-test-without-oidc:
+          context: cpe-gcp
+          filters: *filters
+      - integration-test-with-oidc:
           context: cpe-gcp
           filters: *filters
       - gcp-gcr/build-and-push-image:
@@ -84,7 +110,8 @@ workflows:
           github_token: GHI_TOKEN
           requires:
             - orb-tools/pack
-            - integration-test
+            - integration-test-without-oidc
+            - integration-test-with-oidc
             - build-and-push
             - build-and-push-with-env-var
           context: orb-publisher

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
 
 orbs:
   docker: circleci/docker@1.5
-  gcp-cli: circleci/gcp-cli@3.0
+  gcp-cli: circleci/gcp-cli@3.1

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -47,7 +47,7 @@ parameters:
     default: ""
     description: >
       The list of gcloud components to install. Space separated.
-      See https://cloud.google.com/sdk/docs/components for additional 
+      See https://cloud.google.com/sdk/docs/components for additional
 
   # OIDC parameters
 

--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -33,12 +33,72 @@ parameters:
     type: string
     default: gcr.io
 
+  version:
+    default: latest
+    description: >
+      The version of the gcloud CLI to install. If left to "latest", the latest
+      version will be installed. Otherwise, provide the full version number as
+      it appears in the URL on this page:
+      https://cloud.google.com/sdk/docs/downloads-versioned-archives
+    type: string
+
+  components:
+    type: string
+    default: ""
+    description: >
+      The list of gcloud components to install. Space separated.
+      See https://cloud.google.com/sdk/docs/components for additional 
+
+  # OIDC parameters
+
+  use_oidc:
+    type: boolean
+    default: false
+    description: Set to true to enable OIDC
+
+  google_project_number:
+    type: env_var_name
+    default: GOOGLE_PROJECT_NUMBER
+    description: |
+      Name of environment variable storing the Google project number
+      used to configure OIDC.
+
+  workload_identity_pool_id:
+    type: env_var_name
+    default: OIDC_WIP_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool is stored.
+
+  workload_identity_pool_provider_id:
+    type: env_var_name
+    default: OIDC_WIP_PROVIDER_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool provider ID is stored.
+
+  service_account_email:
+    type: env_var_name
+    default: OIDC_SERVICE_ACCOUNT_EMAIL
+    description: Environment variable containing OIDC service account email.
+
+  gcp_cred_config_file_path:
+    type: string
+    default: ~/gcp_cred_config.json
+    description: Output location of OIDC credentials.
+
 steps:
   - gcp-cli/setup:
+      version: << parameters.version >>
+      components: << parameters.components >>
       google_project_id: <<parameters.google-project-id>>
       google_compute_zone: <<parameters.google-compute-zone>>
       google_compute_region: <<parameters.google-compute-region>>
       gcloud_service_key: <<parameters.gcloud-service-key>>
+      use_oidc: << parameters.use_oidc >>
+      google_project_number: << parameters.google_project_number >>
+      workload_identity_pool_id: << parameters.workload_identity_pool_id >>
+      workload_identity_pool_provider_id: << parameters.workload_identity_pool_provider_id >>
+      service_account_email: << parameters.service_account_email >>
+      gcp_cred_config_file_path: << parameters.gcp_cred_config_file_path >>
 
   - run:
       name: gcloud auth configure-docker

--- a/src/jobs/add-image-tag.yml
+++ b/src/jobs/add-image-tag.yml
@@ -46,6 +46,55 @@ parameters:
     type: string
     description: A new Docker image tag
 
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
+
+  gcloud_components:
+      type: string
+      default: ""
+      description: >
+        The list of gcloud components to install. Space separated.
+        See https://cloud.google.com/sdk/docs/components for additional info.
+
+  # OIDC parameters
+
+  use_oidc:
+    type: boolean
+    default: false
+    description: Set to true to enable OIDC
+
+  google_project_number:
+    type: env_var_name
+    default: GOOGLE_PROJECT_NUMBER
+    description: |
+      Name of environment variable storing the Google project number
+      used to configure OIDC.
+
+  workload_identity_pool_id:
+    type: env_var_name
+    default: OIDC_WIP_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool is stored.
+
+  workload_identity_pool_provider_id:
+    type: env_var_name
+    default: OIDC_WIP_PROVIDER_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool provider ID is stored.
+
+  service_account_email:
+    type: env_var_name
+    default: OIDC_SERVICE_ACCOUNT_EMAIL
+    description: Environment variable containing OIDC service account email.
+
+  gcp_cred_config_file_path:
+    type: string
+    default: ~/gcp_cred_config.json
+    description: Output location of OIDC credentials.
+
 steps:
 
   - gcr-auth:
@@ -53,6 +102,14 @@ steps:
       google-compute-zone: <<parameters.google-compute-zone>>
       google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
+      version: <<parameters.gcloud_version>>
+      components: <<parameters.gcloud_components>>
+      use_oidc: << parameters.use_oidc >>
+      google_project_number: << parameters.google_project_number >>
+      workload_identity_pool_id: << parameters.workload_identity_pool_id >>
+      workload_identity_pool_provider_id: << parameters.workload_identity_pool_provider_id >>
+      service_account_email: << parameters.service_account_email >>
+      gcp_cred_config_file_path: << parameters.gcp_cred_config_file_path >>
 
   - tag-image:
       registry-url: <<parameters.registry-url>>

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -112,6 +112,55 @@ parameters:
       Pass through a default timeout if your Docker build does not output
       anything for more than 10 minutes.
 
+  gcloud_version:
+    type: string
+    default: latest
+    description: |
+      Version of gcloud CLI to install.
+
+  gcloud_components:
+      type: string
+      default: ""
+      description: >
+        The list of gcloud components to install. Space separated.
+        See https://cloud.google.com/sdk/docs/components for additional info.
+
+  # OIDC parameters
+
+  use_oidc:
+    type: boolean
+    default: false
+    description: Set to true to enable OIDC
+
+  google_project_number:
+    type: env_var_name
+    default: GOOGLE_PROJECT_NUMBER
+    description: |
+      Name of environment variable storing the Google project number
+      used to configure OIDC.
+
+  workload_identity_pool_id:
+    type: env_var_name
+    default: OIDC_WIP_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool is stored.
+
+  workload_identity_pool_provider_id:
+    type: env_var_name
+    default: OIDC_WIP_PROVIDER_ID
+    description: |
+      Environment variable containing OIDC configured workload identity pool provider ID is stored.
+
+  service_account_email:
+    type: env_var_name
+    default: OIDC_SERVICE_ACCOUNT_EMAIL
+    description: Environment variable containing OIDC service account email.
+
+  gcp_cred_config_file_path:
+    type: string
+    default: ~/gcp_cred_config.json
+    description: Output location of OIDC credentials.
+
 steps:
   - checkout
 
@@ -128,6 +177,14 @@ steps:
       google-compute-region: <<parameters.google-compute-region>>
       gcloud-service-key: <<parameters.gcloud-service-key>>
       registry-url: <<parameters.registry-url>>
+      version: <<parameters.gcloud_version>>
+      components: <<parameters.gcloud_components>>
+      use_oidc: << parameters.use_oidc >>
+      google_project_number: << parameters.google_project_number >>
+      workload_identity_pool_id: << parameters.workload_identity_pool_id >>
+      workload_identity_pool_provider_id: << parameters.workload_identity_pool_provider_id >>
+      service_account_email: << parameters.service_account_email >>
+      gcp_cred_config_file_path: << parameters.gcp_cred_config_file_path >>
 
   - build-image:
       registry-url: <<parameters.registry-url>>


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

Add oidc support to gcr-auth


## Motivation:

I am using this gcp-gcr orb to push container images to GCR.
I would like to use oidc token auth.
Currently there is not way to do it with  gcr-auth command as it always calls gcp-cli/setup without the OIDC related options.

This fix adds all the latest parameters of gcp-cli/setup to gcr-auth including OIDC.

 **Closes Issues:**
-  https://github.com/CircleCI-Public/gcp-gcr-orb/issues/68

## Checklist:
<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.