### PR TITLE
ci:  migrate to Orb Tools 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
+          exclude: RC010
           filters: *filters
       - shellcheck/check:
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.4
+  orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters
@@ -19,17 +19,10 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/gcp-gcr
-          vcs-type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
-          filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+          orb_name: gcp-gcr
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -40,6 +40,7 @@ workflows:
   test-deploy:
     jobs:
       - integration-test:
+          context: cpe-gcp
           filters: *filters
       - gcp-gcr/build-and-push-image:
           name: build-and-push
@@ -49,6 +50,7 @@ workflows:
           digest-path: /tmp/digest.txt
           path: ~/project/sample/
           docker-context: ~/project/sample/
+          context: cpe-gcp
           filters: *filters
           requires:
             - integration-test

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,10 +1,19 @@
 version: 2.1
+
 orbs:
-  gcp-gcr: circleci/gcp-gcr@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.4
+  gcp-gcr: {}
+  orb-tools: circleci/orb-tools@12
+
 filters: &filters
   tags:
     only: /.*/
+
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
 jobs:
   integration-test:
     executor: gcp-gcr/default
@@ -48,18 +57,16 @@ workflows:
                 command: |
                   echo "Digest is: $(</tmp/digest.txt)"
       - orb-tools/pack:
-          filters: *filters
+          filters: *release-filters
       - orb-tools/publish:
-          orb-name: circleci/gcp-gcr
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
+          orb_name: circleci/gcp-gcr
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          github_token: GHI_TOKEN
           requires:
             - orb-tools/pack
             - integration-test
             - build-and-push
           context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: *release-filters


### PR DESCRIPTION
## Description

This PR updates the GCP GCR Orb to the new major version of Orb Tools.

## Changes

The comprehensive list of changes can be found below.

### Changes in `.circleci/config.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Move the job requirement list from `orb-tools/publish` to `orb-tools/continue`.
1. Remove the `orb-tools/publish` job since development versions are no longer necessary.
1. Add the new `orb_name` parameter in `orb-tools/continue`.
1. Rename the `orb-tools/continue` job parameters to comply with the new snake case standard.
   - `orb_name`, `pipeline_number` and `vcs_type`.

### Changes in `.circleci/test-deploy.yml`:

1. Update the orb-tools version from 11.4 to 12.0.
1. Remove the `gcp-gcr: circleci/gcp-gcr@dev:<<pipeline.git.revision>>` line, and replace it with `gcp-gcr: {}`.
1. Rename the `orb-tools/publish` job parameters to comply with the new snake case standard.
   - `orb_name`, `vcs_type`, `pub_type`, `enable_pr_comment` and `github_token`.
1. Change the `orb-tools/pack` filter to trigger only on tagged releases.
