### PR TITLE
fix: parameter expansion using `circleci env subst`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -58,6 +58,22 @@ workflows:
             - run:
                 command: |
                   echo "Digest is: $(</tmp/digest.txt)"
+      - gcp-gcr/build-and-push-image:
+          name: build-and-push-with-env-var
+          registry-url: us.gcr.io
+          image: ${CIRCLE_PROJECT_REPONAME}
+          tag: ${CIRCLE_SHA1:0:7}.$CIRCLE_BUILD_NUMBER
+          digest-path: /tmp/digest.txt
+          path: ~/project/sample/
+          docker-context: ~/project/sample/
+          context: cpe-gcp
+          filters: *filters
+          requires:
+            - integration-test
+          post-steps:
+            - run:
+                command: |
+                  echo "Digest is: $(</tmp/digest.txt)"
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -70,5 +86,6 @@ workflows:
             - orb-tools/pack
             - integration-test
             - build-and-push
+            - build-and-push-with-env-var
           context: orb-publisher
           filters: *release-filters

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -9,11 +9,15 @@ PROJECT_ID="${!ORB_ENV_PROJECT_ID}"
 
 for tag_to_eval in "${DOCKER_TAGS[@]}"; do
     TAG=$(eval echo "$tag_to_eval")
+    set -x
     docker push "$ORB_VAL_REGISTRY_URL/$PROJECT_ID/$ORB_VAL_IMAGE:$TAG"
+    set +x
 done
 
 if [ -n "$ORB_VAL_DIGEST_PATH" ]; then
     mkdir -p "$(dirname "$ORB_VAL_DIGEST_PATH")"
     SAMPLE_FIRST=$(eval echo "${DOCKER_TAGS[0]}")
+    set -x
     docker image inspect --format="{{index .RepoDigests 0}}" "$ORB_VAL_REGISTRY_URL/$PROJECT_ID/$ORB_VAL_IMAGE:$SAMPLE_FIRST" > "$ORB_VAL_DIGEST_PATH"
+    set +x
 fi

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,5 +1,9 @@
 #!/bin/bash 
 
+ORB_VAL_REGISTRY_URL="$(circleci env subst "$ORB_VAL_REGISTRY_URL")"
+ORB_VAL_IMAGE="$(circleci env subst "$ORB_VAL_IMAGE")"
+ORB_VAL_DIGEST_PATH="$(circleci env subst "$ORB_VAL_DIGEST_PATH")"
+
 IFS="," read -ra DOCKER_TAGS <<< "$ORB_EVAL_TAG"
 PROJECT_ID="${!ORB_ENV_PROJECT_ID}"
 


### PR DESCRIPTION
## Description

Closes #65 and #66. 

Due to the Orb Tools migration, some commands lost the expansion functionality; therefore, the CLI command received literal variables (e.g. `CIRCLE_PROJECT_REPONAME`). 

This PR leverages the recently introduced `circleci env subst` to expand the parameters and restore the lost functionality.