### PR TITLE
[semver:patch] fix: Update gcr-auth to run on Windows executors

### DIFF
--- a/src/scripts/gcr-auth.sh
+++ b/src/scripts/gcr-auth.sh
@@ -1,7 +1,23 @@
-#!/bin/bash 
+#!/usr/bin/env bash
+
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     platform=linux;;
+    Darwin*)    platform=mac;;
+    CYGWIN*)    platform=windows;;
+    MINGW*)     platform=windows;;
+    MSYS_NT*)   platform=windows;;
+    *)          platform="UNKNOWN:${unameOut}"
+esac
+
+if [ "${platform}" != "windows" ] && ! command -v sudo > /dev/null 2>&1; then
+  printf '%s\n' "sudo is required to configure Docker to use GCP repositories."
+  printf '%s\n' "Please install it and try again."
+  return 1
+fi
 
 # Set sudo to work whether logged in as root user or non-root user
-if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+if [[ $EUID == 0 ]] || [[ "${platform}" == "windows" ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # configure Docker to use gcloud as a credential helper
 mkdir -p "$HOME/.docker"


### PR DESCRIPTION
This is to fix the error in this issue: https://github.com/CircleCI-Public/gcp-gcr-orb/issues/88.

Note: This only fixes the immediate error when running the gcr-auth.sh script on a Windows executor. There may be additional errors running subsequent docker build and push commands on the Windows executor.