### PR TITLE
Remove restriction of only using machine executor

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -1,5 +1,5 @@
 description: >
-  Configure Docker to use gcloud as a credential helper. Using this command requires the use of a 'machine' executor.
+  Configure Docker to use gcloud as a credential helper.
 
 parameters:
   gcloud-service-key:


### PR DESCRIPTION
Description of gcr-auth shows that it requires a 'machine' executor. I have been using gcr-auth using a docker executor without any issue.