### PR TITLE
Update description of gcr-auth

### DIFF
--- a/src/commands/gcr-auth.yml
+++ b/src/commands/gcr-auth.yml
@@ -1,5 +1,5 @@
 description: >
-  Configure Docker to use gcloud as a credential helper. Using this command requires the use of a 'machine' executor.
+  Configure Docker to use gcloud as a credential helper.
 
 parameters:
   gcloud-service-key:


### PR DESCRIPTION
Description of gcr-auth mentions that it requires a 'machine' executor. It doesn't seem to be the case anymore as it can be used with a docker executor as well without issue.