### PR TITLE
feat(artifact-registry): add support to artifact registry repository format

### DIFF
--- a/src/commands/build-image.yml
+++ b/src/commands/build-image.yml
@@ -5,7 +5,14 @@ parameters:
     type: string
     default: gcr.io
     description: The GCR registry URL from ['', us, eu, asia].gcr.io
-
+  
+  repository:
+    type: string
+    default: ""
+    description: >
+      The Artifact Registry requires a HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE format.
+      If pushing to the Artifact Registry, the repository to push the image to
+      
   google-project-id:
     type: env_var_name
     default: GOOGLE_PROJECT_ID
@@ -73,14 +80,32 @@ steps:
       steps:
         - attach_workspace:
             at: <<parameters.workspace-root>>
-
-  - docker/build:
-      step-name: Build Docker image for GCR
-      dockerfile: <<parameters.dockerfile>>
-      docker-context: <<parameters.docker-context>>
-      path: <<parameters.path>>
-      registry: "<<parameters.registry-url>>/$<<parameters.google-project-id>>"
-      image: <<parameters.image>>
-      tag: <<parameters.tag>>
-      extra_build_args: <<parameters.extra_build_args>>
-      no_output_timeout: <<parameters.no_output_timeout>>
+  - when:
+      condition: 
+        equal: [ "", << parameters.repository >> ]
+      steps:
+        - docker/build:
+            step-name: Build Docker image for GCR
+            dockerfile: <<parameters.dockerfile>>
+            docker-context: <<parameters.docker-context>>
+            path: <<parameters.path>>
+            registry: "<<parameters.registry-url>>/$<<parameters.google-project-id>>"
+            image: <<parameters.image>>
+            tag: <<parameters.tag>>
+            extra_build_args: <<parameters.extra_build_args>>
+            no_output_timeout: <<parameters.no_output_timeout>>
+  - when:
+      condition: 
+        not:
+          equal: [ "", << parameters.repository >> ]
+      steps:
+        - docker/build:
+            step-name: Build Docker image for GCR
+            dockerfile: <<parameters.dockerfile>>
+            docker-context: <<parameters.docker-context>>
+            path: <<parameters.path>>
+            registry: "<<parameters.registry-url>>/$<<parameters.google-project-id>>/<<parameters.repository>>"
+            image: <<parameters.image>>
+            tag: <<parameters.tag>>
+            extra_build_args: <<parameters.extra_build_args>>
+            no_output_timeout: <<parameters.no_output_timeout>>

--- a/src/commands/push-image.yml
+++ b/src/commands/push-image.yml
@@ -5,7 +5,14 @@ parameters:
     description: The GCR registry URL from ['', us, eu, asia].gcr.io
     type: string
     default: gcr.io
-
+  
+  repository:
+    type: string
+    default: ""
+    description: >
+      The Artifact Registry requires a HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE format.
+      If pushing to the Artifact Registry, the repository to push the image to
+      
   google-project-id:
     description: The Google project ID to connect with via the gcloud CLI
     type: env_var_name
@@ -31,6 +38,7 @@ steps:
       environment:
         ORB_ENV_PROJECT_ID: << parameters.google-project-id >>
         ORB_VAL_REGISTRY_URL: << parameters.registry-url >>
+        ORB_VAL_REPOSITORY: << parameters.repository >>
         ORB_VAL_IMAGE: << parameters.image >>
         ORB_VAL_DIGEST_PATH: << parameters.digest-path >>
         ORB_EVAL_TAG: << parameters.tag >>

--- a/src/examples/simple-build-and-push-artifact-registry.yml
+++ b/src/examples/simple-build-and-push-artifact-registry.yml
@@ -1,0 +1,17 @@
+description: >
+  Log into Google Cloud Plaform, then build and push image to Artifact Registry
+
+usage:
+  version: 2.1
+
+  orbs:
+    gcp-gcr: circleci/gcp-gcr@x.y.z
+
+  workflows:
+    build_and_push_image:
+      jobs:
+        - gcp-gcr/build-and-push-image:
+            context: myContext # your context containing gcloud login variables
+            registry-url: us-central1-docker.pkg.dev # gcr.io, eu.gcr.io, asia.gcr.io
+            repository: my-repo # your repository name
+            image: my-image # your image name

--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -36,6 +36,13 @@ parameters:
     type: string
     default: gcr.io
 
+  repository:
+    type: string
+    default: ""
+    description: >
+      The Artifact Registry requires a HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE format.
+      If pushing to the Artifact Registry, the repository to push the image to
+
   image:
     type: string
     description: A name for your Docker image
@@ -188,6 +195,7 @@ steps:
 
   - build-image:
       registry-url: <<parameters.registry-url>>
+      repository: <<parameters.repository>>
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>
@@ -201,6 +209,7 @@ steps:
 
   - push-image:
       registry-url: <<parameters.registry-url>>
+      repository: <<parameters.repository>>
       google-project-id: <<parameters.google-project-id>>
       image: <<parameters.image>>
       tag: <<parameters.tag>>

--- a/src/scripts/push-image.sh
+++ b/src/scripts/push-image.sh
@@ -1,16 +1,22 @@
 #!/bin/bash 
 
 ORB_VAL_REGISTRY_URL="$(circleci env subst "$ORB_VAL_REGISTRY_URL")"
+ORB_VAL_REPOSITORY="$(circleci env subst "$ORB_VAL_REPOSITORY")"
 ORB_VAL_IMAGE="$(circleci env subst "$ORB_VAL_IMAGE")"
 ORB_VAL_DIGEST_PATH="$(circleci env subst "$ORB_VAL_DIGEST_PATH")"
 
 IFS="," read -ra DOCKER_TAGS <<< "$ORB_EVAL_TAG"
 PROJECT_ID="${!ORB_ENV_PROJECT_ID}"
 
+DOCKER_PATH="$ORB_VAL_REGISTRY_URL/$PROJECT_ID/$ORB_VAL_IMAGE:$TAG"
+if [ -n "${ORB_VAL_REPOSITORY}" ]; then
+    DOCKER_PATH="$ORB_VAL_REGISTRY_URL/$PROJECT_ID/$ORB_VAL_REPOSITORY/$ORB_VAL_IMAGE:$TAG"
+fi
+
 for tag_to_eval in "${DOCKER_TAGS[@]}"; do
     TAG=$(eval echo "$tag_to_eval")
     set -x
-    docker push "$ORB_VAL_REGISTRY_URL/$PROJECT_ID/$ORB_VAL_IMAGE:$TAG"
+    docker push "$DOCKER_PATH"
     set +x
 done
 


### PR DESCRIPTION
Google has deprecated the Container Registry in favor of the new Artifact Registry.

The Artifact Registry requires a `HOST-NAME/PROJECT-ID/REPOSITORY/IMAGE` format. 
Since all of the configuration attaches the **project-id** after the **registry-url**, we can't send a custom value on the registry URL that would include the repository name.

Supporting the Artifact Registry by adding a new non-required parameter if we want to push it to the Artifact Registry.

TODO: This doesn't include the tag image command. Let me know if it should be included.

This is also required to update the `gcp-gke` Orb to allow to build, push and deploy Kubernetes images from the Artifact Registry.

