### PR TITLE
Removing SUDO mandatory dependency

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -81,8 +81,6 @@ workflows:
       - test-without-sudo:
           context: cpe-gcp
           filters: *filters
-          requires:
-            - integration-test-without-oidc
           post-steps:
             - run:
                 command: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,6 +15,12 @@ release-filters: &release-filters
     only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 jobs:
+  test-without-sudo:
+    docker:
+      - image: google/cloud-sdk:latest
+    steps:
+      - checkout
+      - gcp-gcr/gcr-auth
   integration-test-without-oidc:
     executor: gcp-gcr/default
     steps:
@@ -72,6 +78,15 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - test-without-sudo:
+          context: cpe-gcp
+          filters: *filters
+          requires:
+            - integration-test-without-oidc
+          post-steps:
+            - run:
+                command: |
+                  gcloud version
       - integration-test-without-oidc:
           context: cpe-gcp
           filters: *filters

--- a/src/scripts/gcr-auth.sh
+++ b/src/scripts/gcr-auth.sh
@@ -10,14 +10,12 @@ case "${unameOut}" in
     *)          platform="UNKNOWN:${unameOut}"
 esac
 
-if [ "${platform}" != "windows" ] && ! command -v sudo > /dev/null 2>&1; then
-  printf '%s\n' "sudo is required to configure Docker to use GCP repositories."
-  printf '%s\n' "Please install it and try again."
-  return 1
-fi
-
 # Set sudo to work whether logged in as root user or non-root user
-if [[ $EUID == 0 ]] || [[ "${platform}" == "windows" ]]; then export SUDO=""; else export SUDO="sudo"; fi
+if [[ $EUID == 0 ]] || [[ "${platform}" == "windows" ]]; then
+    export SUDO=""
+else
+    export SUDO="sudo"
+fi
 
 # configure Docker to use gcloud as a credential helper
 mkdir -p "$HOME/.docker"


### PR DESCRIPTION
Fixes #96 
This PR removes the logic that checks for SUDO availability.
The SUDO variable handles its value as empty or not depending on sudo availability
This PR also adds a new test to validate it works in scenarios without sudo available