### PR TITLE
Update default docker version for build and push job

### DIFF
--- a/src/jobs/build-and-push-image.yml
+++ b/src/jobs/build-and-push-image.yml
@@ -107,7 +107,7 @@ parameters:
       Setup docker layer caching for optimized build. Not available if using the default executor.
     type: boolean
   remote-docker-version:
-    default: "17.09.0-ce"
+    default: "docker24"
     description: |
       Specify the remote docker version. See: https://circleci.com/docs/2.0/building-docker-images/#docker-version
     type: string


### PR DESCRIPTION
This PR updates the default docker execution environment to the lates supported one given this [documentation](https://circleci.com/docs/building-docker-images/#docker-version).

The PR just updates the build and push job docker environment from "17.09.0-ce" to "docker24"