### PR TITLE
[semver:patch] Add missing env subst in gcr-auth

### DIFF
--- a/src/scripts/gcr-auth.sh
+++ b/src/scripts/gcr-auth.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ORB_VAL_REGISTRY_URL="$(circleci env subst "$ORB_VAL_REGISTRY_URL")"
+
 unameOut="$(uname -s)"
 case "${unameOut}" in
     Linux*)     platform=linux;;


### PR DESCRIPTION
While [push-image](https://github.com/CircleCI-Public/gcp-gcr-orb/blob/master/src/scripts/push-image.sh#L3) and [tag-image](https://github.com/CircleCI-Public/gcp-gcr-orb/blob/master/src/scripts/tag-image.sh#L3) support passing env variable to `registry-url`, gcr-auth is missing it.

This PR adds support of env variable for `registry-url` to gcr-auth.